### PR TITLE
A Few Additions / Changes

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -26,7 +26,7 @@ fn main() {
     match do_stuff() {
         Ok(_) => (),
         Err(e) => {
-            println!("{:?}", e);
+            println!("{}", e);
             ()
         }
     }

--- a/src/bin/rustping.rs
+++ b/src/bin/rustping.rs
@@ -8,7 +8,7 @@ macro_rules! perror {
         match $e {
             Ok(x) => x,
             Err(e) => {
-                println!("{}: {:?}", $prefix, e);
+                println!("{}: {}", $prefix, e);
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
- Implement fmt::Display and error::Error for PingError.
- Provide the encountered std::ffi::NulError in PingError::NulByteError.
- Move/update docs for each PingError variant.
