### PR TITLE
Fixing deprecated gcc call; adding ability for custom PingError

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn main() {
         .status()
         .unwrap();
 
-    gcc::Config::new()
+    gcc::Build::new()
         .define("HAVE_CONFIG_H", None)
         .file("liboping/src/liboping.c")
         .include("liboping/src/")

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,12 +1,29 @@
 extern crate oping;
-use oping::{Ping, PingResult};
+use oping::{Ping, PingResult, PingError};
 
 fn do_stuff() -> PingResult<()> {
     let mut ping = Ping::new();
     try!(ping.set_timeout(5.0));  // timeout of 5.0 seconds
     try!(ping.add_host("localhost"));  // fails here if socket can't be created
     try!(ping.add_host("::1"));  // IPv4 / IPv6 addresses OK
-    try!(ping.add_host("1.2.3.4"));
+    
+    /* Replacing the following 'try' macro with an example of how to use
+     * my PingError::CustomError. I suggest adding a broken IP Address like
+     * 1.300.1.1 to see it in action.
+     *      - Timmonfette1
+     *
+     * try!(ping.add_host("1.2.3.4"));
+     */
+    let ip = "1.2.3.4";
+    match ping.add_host(ip) {
+        Ok(_)  => (),
+        Err(e) =>
+        {
+            let error_message = format!("Failure from {} - {}", ip, e);
+            return Err(PingError::CustomError(error_message));
+        }
+    }
+    
     let responses = try!(ping.send());  // waits for responses from all, or timeout
     for resp in responses {
         if resp.dropped > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ use libc::c_int;
 use self::PingError::{
     LibOpingError,
     NulByteError,
+    CustomError,
 };
 
 /// Address family (IPv4 or IPv6) used to send/receive a ping.
@@ -127,6 +128,8 @@ pub enum PingError {
     LibOpingError(String),
     /// A `std::ffi::NulError` that occurred while trying to convert a hostname string
     NulByteError(NulError),
+    /// An error with a custom error message
+    CustomError(String),
 }
 
 impl fmt::Display for PingError {
@@ -134,6 +137,7 @@ impl fmt::Display for PingError {
         match *self {
             LibOpingError(ref err) => write!(f, "oping::PingError::LibOpingError: {}", err),
             NulByteError(ref err) => write!(f, "oping::PingError::NulByteError: {}", err),
+            CustomError(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -143,6 +147,7 @@ impl error::Error for PingError {
         match *self {
             LibOpingError(_) => "a liboping internal error was encountered",
             NulByteError(ref e) => e.description(),
+            CustomError(ref e) => &e,
         }
     }
 


### PR DESCRIPTION
There was a deprecated gcc call in the build.rs, so that was a quick fix. I also added the ability to create a custom error message in a PingError instead of being limited to only a LibOpingError or a NulByteError. That custom error message will just be displayed as is. Finally, the simple.rs in "examples/" is updated to remove a try macro to show how to use the PingError::CustomError.  It was tested and builds, compiles, and the simple.rs prints out the expected results.