### PR TITLE
Implement ability to link with liboping via pkg-config.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [build-dependencies]
 cc = "1.0"
+pkg-config = "0.3"
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,30 @@ use std::process::Command;
 
 extern crate cc;
 
+const LIBOPING_VERSION: &str = "1.10.0";
+
 fn main() {
+    match std::env::var("RUST_OPING_USE_PKG_CONFIG") {
+        Ok(_) => link_via_pkg_config(),
+        Err(_) => build_and_statically_link()
+    }
+}
+
+fn link_via_pkg_config() {
+    if let Err(err) = pkg_config::Config::new()
+        .exactly_version(LIBOPING_VERSION)
+        .cargo_metadata(true)
+        .probe("liboping")
+    {
+        panic!(
+            "Could not find liboping via pkg-config: {:?}\nPKG_CONFIG_SYSROOT_DIR={}",
+            err,
+            std::env::var("PKG_CONFIG_SYSROOT_DIR").unwrap_or_default()
+        );
+    }
+}
+
+fn build_and_statically_link() {
     Command::new("sh")
         .current_dir("liboping/")
         .arg("autogen.sh")


### PR DESCRIPTION
I needed to dynamically link with a target installation of liboping when cross compiling. Happy to refactor as needed to get this merged into mainline.